### PR TITLE
fix: update OpenSSL dependency for Alpine compatibility

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -2,6 +2,12 @@
 FROM node:20.18.1-alpine AS production
 WORKDIR /usr/src
 
+RUN apk add --no-cache \
+  openssl \
+  libssl3 \
+  libgcc \
+  libc6-compat
+
 COPY --chown=node:node package*.json ./
 RUN npm ci --production
 


### PR DESCRIPTION
This PR resolves a compatibility issue when building the Docker image with Prisma on Alpine Linux. The error occurred due to the missing libssl.so.1.1 library, which is no longer supported in Alpine 3.18+.

**Changes Made:**
- Updated the Dockerfile to explicitly install libssl3 instead of libssl1.1.
- Ensured all necessary dependencies (openssl, libgcc, libc6-compat) are installed for Prisma's query engine compatibility.

**Reason for the Fix**
Prisma's query engine depends on libssl.so.1.1, but Alpine Linux has transitioned to libssl3. Without this fix, the application fails to initialize the Prisma client with the following error:
```bash
Error loading shared library libssl.so.1.1: No such file or directory
```

**Additional Notes**
- This fix ensures compatibility with Alpine 3.18+ without increasing the image size significantly
- The approach keeps the Docker image lightweight and aligned with best practices