### PR TITLE
fix: setup a dedicated .env file for docker local development

### DIFF
--- a/services/api/.env.development.example
+++ b/services/api/.env.development.example
@@ -1,0 +1,3 @@
+NODE_ENV=production
+PORT=9080
+DATABASE_URL="postgresql://docker:randompasswd@api-db-1:5432/mvp_db?schema=public"

--- a/services/api/docker-compose.yml
+++ b/services/api/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  task-api-db:
+  db:
     image: bitnami/postgresql
     ports:
       - 5432:5432
@@ -8,13 +8,13 @@ services:
       - POSTGRESQL_PASSWORD=D7uli0o71H
       - POSTGRESQL_DATABASE=mvp_db
 
-  task-api:
+  app:
     build:
       context: ./
       dockerfile: Dockerfile
     ports:
       - 9080:9080
     env_file:
-      - ./.env
+      - ./.env.development.local
     depends_on:
-      - task-api-db
+      - db


### PR DESCRIPTION
This PR solves the communication problem between app x db containers.

**Changes Made:**
- Update docker-compose file to load a dedicated .env
- Creating a .env decided for the local docker environment

**Reason for the Fix:**
```bash
2024-12-18 18:56:06 Can't reach database server at localhost:5432
2024-12-18 18:56:06 Please make sure your database server is running at localhost:5432.
```